### PR TITLE
Fix invalid use of gitHubRepo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     <scm>
         <connection>scm:git:git@github.com:${gitHubRepo}.git</connection>
         <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
-        <url>git@github.com:jenkinsci/${gitHubRepo}.git</url>
+        <url>https://github.com:${gitHubRepo}</url>
         <tag>${scmTag}</tag>
     </scm>
     <properties>


### PR DESCRIPTION
SCM URL in pom.xml is invalid and thus plugin wiki page is not correctly generated