### PR TITLE
Allow easier API logging via log recorder

### DIFF
--- a/src/main/java/cloud/dnation/jenkins/plugins/hetzner/HetznerConstants.java
+++ b/src/main/java/cloud/dnation/jenkins/plugins/hetzner/HetznerConstants.java
@@ -34,11 +34,6 @@ public class HetznerConstants {
     public static final String PROP_API_ENDPOINT = PROP_PREFIX + ".api-endpoint";
 
     /**
-     * Name of system property used to configure debug logging of Hetzner API client.
-     */
-    public static final String PROP_CLIENT_DEBUG = PROP_PREFIX + ".client-debug";
-
-    /**
      * Hetzner public cloud API endpoint.
      */
     public static final String DEFAULT_ENDPOINT = "https://api.hetzner.cloud/v1/";

--- a/src/main/java/cloud/dnation/jenkins/plugins/hetzner/client/ClientFactory.java
+++ b/src/main/java/cloud/dnation/jenkins/plugins/hetzner/client/ClientFactory.java
@@ -38,12 +38,10 @@ public class ClientFactory {
     private static final Gson GSON = new GsonBuilder().create();
 
     private static HetznerApi create(String apiToken) {
-        final boolean debug = Boolean.TRUE.toString().equals(System.getProperty(HetznerConstants.PROP_CLIENT_DEBUG,
-                Boolean.FALSE.toString()));
-        final HttpLoggingInterceptor loggingInterceptor = new HttpLoggingInterceptor();
+        final HttpLoggingInterceptor loggingInterceptor = new HttpLoggingInterceptor(log::trace);
         //noinspection UnstableApiUsage
         loggingInterceptor.redactHeader(HttpHeaders.AUTHORIZATION);
-        loggingInterceptor.setLevel(debug ? HttpLoggingInterceptor.Level.BASIC : HttpLoggingInterceptor.Level.NONE);
+        loggingInterceptor.setLevel(HttpLoggingInterceptor.Level.BODY);
         final OkHttpClient client = new OkHttpClient.Builder()
                 .connectionPool(CP)
                 .addInterceptor(new AuthenticationInterceptor(apiToken))


### PR DESCRIPTION
As mentioned in #21 we need simple way to capture API errors.

API requests and responses are logged at TRACE level, so by default they won't be present in log.
They can be however seen when configured in log recorder.

