### PR TITLE
Ensure correct RetentionPolicy is used

### DIFF
--- a/src/main/java/cloud/dnation/jenkins/plugins/hetzner/HetznerServerTemplate.java
+++ b/src/main/java/cloud/dnation/jenkins/plugins/hetzner/HetznerServerTemplate.java
@@ -19,7 +19,6 @@ import cloud.dnation.jenkins.plugins.hetzner.connect.AbstractConnectivity;
 import cloud.dnation.jenkins.plugins.hetzner.launcher.AbstractHetznerSshConnector;
 import cloud.dnation.jenkins.plugins.hetzner.primaryip.AbstractPrimaryIpStrategy;
 import cloud.dnation.jenkins.plugins.hetzner.shutdown.AbstractShutdownPolicy;
-import cloud.dnation.jenkins.plugins.hetzner.shutdown.IdlePeriodPolicy;
 import com.google.common.base.Strings;
 import hudson.Extension;
 import hudson.Util;
@@ -94,10 +93,6 @@ public class HetznerServerTemplate extends AbstractDescribableImpl<HetznerServer
     @Getter
     private String jvmOpts;
 
-    @Deprecated
-    @Getter
-    private String keepAroundMinutes;
-
     @Getter
     @Setter(onMethod = @__({@DataBoundSetter}))
     private int numExecutors;
@@ -159,16 +154,6 @@ public class HetznerServerTemplate extends AbstractDescribableImpl<HetznerServer
             connectivity = HetznerConstants.DEFAULT_CONNECTIVITY;
         }
         return this;
-    }
-
-    @Deprecated
-    @DataBoundSetter
-    public void setKeepAroundMinutes(String keepAroundMinutes) {
-        if (!Strings.isNullOrEmpty(keepAroundMinutes)) {
-            log.info("{} : Migrating keepAroundMinutes to shutdown policy {}", name, keepAroundMinutes);
-            shutdownPolicy = new IdlePeriodPolicy(Integer.parseInt(keepAroundMinutes));
-        }
-        this.keepAroundMinutes = null;
     }
 
     /**

--- a/src/main/java/cloud/dnation/jenkins/plugins/hetzner/shutdown/AbstractShutdownPolicy.java
+++ b/src/main/java/cloud/dnation/jenkins/plugins/hetzner/shutdown/AbstractShutdownPolicy.java
@@ -20,12 +20,14 @@ import hudson.slaves.AbstractCloudComputer;
 import hudson.slaves.RetentionStrategy;
 import lombok.Getter;
 
+import java.util.Objects;
+
 @SuppressWarnings("rawtypes")
 public abstract class AbstractShutdownPolicy extends AbstractDescribableImpl<AbstractShutdownPolicy> {
     @Getter
     protected final transient RetentionStrategy<AbstractCloudComputer> retentionStrategy;
 
     protected AbstractShutdownPolicy(RetentionStrategy<AbstractCloudComputer> strategy) {
-        this.retentionStrategy = strategy;
+        this.retentionStrategy = Objects.requireNonNull(strategy);
     }
 }

--- a/src/main/java/cloud/dnation/jenkins/plugins/hetzner/shutdown/BeforeHourWrapsPolicy.java
+++ b/src/main/java/cloud/dnation/jenkins/plugins/hetzner/shutdown/BeforeHourWrapsPolicy.java
@@ -41,6 +41,11 @@ public class BeforeHourWrapsPolicy extends AbstractShutdownPolicy {
         super(STRATEGY_SINGLETON);
     }
 
+    @SuppressWarnings("rawtypes")
+    @Override
+    public RetentionStrategy<AbstractCloudComputer> getRetentionStrategy() {
+        return STRATEGY_SINGLETON;
+    }
 
     @SuppressWarnings("rawtypes")
     private static class RetentionStrategyImpl extends RetentionStrategy<AbstractCloudComputer> {


### PR DESCRIPTION
Override getRetentionStrategy() in BeforeHourWrapsPolicy
    
For some reason, value maintained by hudson.model.Slave is null under
cirsumstances described in #56, which is causing return value to be
set to RetentionStrategy.Always.INSTANCE.
    
Closes #56
