### PR TITLE
Add support for cloud-init user-data

### DIFF
--- a/src/main/java/cloud/dnation/jenkins/plugins/hetzner/HetznerCloudResourceManager.java
+++ b/src/main/java/cloud/dnation/jenkins/plugins/hetzner/HetznerCloudResourceManager.java
@@ -278,6 +278,9 @@ public class HetznerCloudResourceManager {
                     createServerRequest.setPlacementGroup(getPlacementGroupForLabelExpression(placementGroup));
                 }
             }
+            if (!Strings.isNullOrEmpty(agent.getTemplate().getUserData())) {
+                createServerRequest.setUserData(agent.getTemplate().getUserData());
+            }
             createServerRequest.setServerType(agent.getTemplate().getServerType());
             createServerRequest.setImage(imageId);
             createServerRequest.setName(agent.getNodeName());

--- a/src/main/java/cloud/dnation/jenkins/plugins/hetzner/HetznerServerTemplate.java
+++ b/src/main/java/cloud/dnation/jenkins/plugins/hetzner/HetznerServerTemplate.java
@@ -96,6 +96,10 @@ public class HetznerServerTemplate extends AbstractDescribableImpl<HetznerServer
 
     @Setter(onMethod = @__({@DataBoundSetter}))
     @Getter
+    private String userData;
+
+    @Setter(onMethod = @__({@DataBoundSetter}))
+    @Getter
     private String jvmOpts;
 
     @Getter
@@ -160,6 +164,9 @@ public class HetznerServerTemplate extends AbstractDescribableImpl<HetznerServer
         }
         if (placementGroup == null) {
             placementGroup = "";
+        }
+        if (userData == null) {
+            userData = "";
         }
         return this;
     }

--- a/src/main/resources/cloud/dnation/jenkins/plugins/hetzner/HetznerServerTemplate/config.jelly
+++ b/src/main/resources/cloud/dnation/jenkins/plugins/hetzner/HetznerServerTemplate/config.jelly
@@ -67,4 +67,9 @@
 
         <f:dropdownDescriptorSelector field="connectivity" title="${%Connectivity}" />
     </f:advanced>
+    <f:advanced title="${%Other}" align="left">
+        <f:entry title="${%User data}" field="userData">
+            <f:textarea/>
+        </f:entry>
+    </f:advanced>
 </j:jelly>

--- a/src/main/resources/cloud/dnation/jenkins/plugins/hetzner/HetznerServerTemplate/help-userData.html
+++ b/src/main/resources/cloud/dnation/jenkins/plugins/hetzner/HetznerServerTemplate/help-userData.html
@@ -1,0 +1,19 @@
+<!--
+     Copyright 2022 https://dnation.cloud
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<div>
+    Cloud-Init user data to use during Server creation.
+    This field is limited to 32KiB by Hetzner Cloud itself.
+</div>


### PR DESCRIPTION
This plugin now allow user to specify cloud-init user-data. Value is passed as-is to cloud API

Closes #60
