### PR TITLE
Adopt to upcoming changes in Hetzner Cloud API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
         <dependency>
             <groupId>cloud.dnation.integration</groupId>
             <artifactId>hetzner-cloud-client-java</artifactId>
-            <version>1.3.0</version>
+            <version>1.6.0</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/cloud/dnation/jenkins/plugins/hetzner/ConfigurationValidator.java
+++ b/src/main/java/cloud/dnation/jenkins/plugins/hetzner/ConfigurationValidator.java
@@ -106,8 +106,8 @@ public class ConfigurationValidator {
                         "Expected exactly one result, got %s", result.getImages().size());
                 return new ValidationResult(true, "Found: " +
                         result.getImages().get(0).getDescription());
-            } else if (Helper.isPossiblyInteger(image)) {
-                final GetImageByIdResponse result = api.getImageById(Integer.parseInt(image)).execute().body();
+            } else if (Helper.isPossiblyLong(image)) {
+                final GetImageByIdResponse result = api.getImageById(Long.parseLong(image)).execute().body();
                 return new ValidationResult(true, "Found: " +
                         result.getImage().getDescription());
             } else {
@@ -128,7 +128,7 @@ public class ConfigurationValidator {
                 return new ValidationResult(true, "Found: " +
                         result.getNetworks().get(0).getName() + " " +
                         result.getNetworks().get(0).getIpRange());
-            } else if (Helper.isPossiblyInteger(network)) {
+            } else if (Helper.isPossiblyLong(network)) {
                 final GetNetworkByIdResponse result = api.getNetworkById(Integer.parseInt(network)).execute().body();
                 return new ValidationResult(true, "Found: " +
                         result.getNetwork().getName() + " " + result.getNetwork().getIpRange());
@@ -150,7 +150,7 @@ public class ConfigurationValidator {
                 return new ValidationResult(true, "Found: " +
                         result.getPlacementGroups().get(0).getName() + " " +
                         result.getPlacementGroups().get(0).getId());
-            } else if (Helper.isPossiblyInteger(placementGroup)) {
+            } else if (Helper.isPossiblyLong(placementGroup)) {
                 final GetPlacementGroupByIdResponse result = api.getPlacementGroupById(Integer.parseInt(placementGroup)).execute().body();
                 return new ValidationResult(true, "Found: " +
                         result.getPlacementGroup().getName() + " " + result.getPlacementGroup().getId());

--- a/src/main/java/cloud/dnation/jenkins/plugins/hetzner/Helper.java
+++ b/src/main/java/cloud/dnation/jenkins/plugins/hetzner/Helper.java
@@ -20,7 +20,6 @@ import com.cloudbees.plugins.credentials.CredentialsMatchers;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
-import com.google.common.primitives.Ints;
 import com.trilead.ssh2.crypto.PEMDecoder;
 import hudson.security.ACL;
 import jenkins.model.Jenkins;
@@ -92,14 +91,18 @@ public class Helper {
     }
 
     /**
-     * Check if given string could be parsed as positive integer.
+     * Check if given string could be parsed as positive long.
      *
      * @param str string to check
-     * @return <code>true</code> if given string could be parsed as positive integer, <code>false</code> otherwise
+     * @return <code>true</code> if given string could be parsed as positive long, <code>false</code> otherwise
      */
-    public static boolean isPossiblyInteger(String str) {
-        final Integer value = Ints.tryParse(str);
-        return value != null && value > 0;
+    public static boolean isPossiblyLong(String str) {
+        try {
+            final long value = Long.parseLong(str);
+            return value > 0;
+        } catch (NumberFormatException e) {
+            return false;
+        }
     }
 
     public static <T, E> List<E> getPayload(@Nonnull Response<T> response, @Nonnull Function<T, List<E>> mapper) {

--- a/src/main/java/cloud/dnation/jenkins/plugins/hetzner/primaryip/AbstractByLabelSelector.java
+++ b/src/main/java/cloud/dnation/jenkins/plugins/hetzner/primaryip/AbstractByLabelSelector.java
@@ -38,7 +38,7 @@ public abstract class AbstractByLabelSelector extends AbstractPrimaryIpStrategy 
 
     @Override
     public void applyInternal(HetznerApi api, CreateServerRequest server) throws IOException {
-        final PrimaryIpDetail pip = api.getAllPrimaryIps(selector).execute().body().getIps().stream()
+        final PrimaryIpDetail pip = api.getAllPrimaryIps(selector).execute().body().getPrimaryIps().stream()
                 .filter(ip -> isIpUsable(ip, server)).findFirst().get();
         final PublicNetRequest net = new PublicNetRequest();
         net.setIpv4(pip.getId());

--- a/src/test/java/cloud/dnation/jenkins/plugins/hetzner/HelperTest.java
+++ b/src/test/java/cloud/dnation/jenkins/plugins/hetzner/HelperTest.java
@@ -58,4 +58,11 @@ public class HelperTest {
         assertFalse(Helper.canShutdownServer(str, time("2022-08-08T11:03:02")));
         assertTrue(Helper.canShutdownServer(str, time("2022-08-08T11:59:02")));
     }
+
+    @Test
+    public void testIsPossiblyLong() {
+        assertTrue(Helper.isPossiblyLong("1"));
+        assertFalse(Helper.isPossiblyLong("0"));
+        assertFalse(Helper.isPossiblyLong("not-a-number"));
+    }
 }

--- a/src/test/java/cloud/dnation/jenkins/plugins/hetzner/primaryip/PrimaryIpStrategyTest.java
+++ b/src/test/java/cloud/dnation/jenkins/plugins/hetzner/primaryip/PrimaryIpStrategyTest.java
@@ -63,7 +63,7 @@ public class PrimaryIpStrategyTest {
         assertFalse(isIpUsable(ip, server));
 
         //Already allocated
-        ip.setAssigneeId(0);
+        ip.setAssigneeId(0L);
         assertFalse(isIpUsable(ip, server));
     }
 }


### PR DESCRIPTION
Starting on 1st September, Hetzner Cloud API will start to use 52-bit IDs. Client library already adopted to this change.
Update code so it uses `long`s instead of `integer`s where it deal with IDs.

See more info here https://docs.hetzner.cloud/changelog#2023-05-15-api-will-return-up-to-52-bit-ids
