### PR TITLE
Validate that cloud name is valid label value.

### DIFF
--- a/src/main/java/cloud/dnation/jenkins/plugins/hetzner/Helper.java
+++ b/src/main/java/cloud/dnation/jenkins/plugins/hetzner/Helper.java
@@ -51,12 +51,14 @@ import java.util.function.Function;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.SimpleFormatter;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static cloud.dnation.jenkins.plugins.hetzner.HetznerConstants.SHUTDOWN_TIME_BUFFER;
 
 @UtilityClass
 public class Helper {
+    private static final Pattern LABEL_VALUE_RE = Pattern.compile("^(?![0-9]+$)(?!-)[a-zA-Z0-9-_.]{0,63}(?<!-)$");
     private static final String SSH_RSA = "ssh-rsa";
 
     /**
@@ -201,5 +203,12 @@ public class Helper {
                 .filter(HetznerServerAgent.class::isInstance)
                 .map(HetznerServerAgent.class::cast)
                 .collect(Collectors.toList());
+    }
+
+    public static boolean isValidLabelValue(String value) {
+        if (Strings.isNullOrEmpty(value)) {
+            return false;
+        }
+        return LABEL_VALUE_RE.matcher(value).matches();
     }
 }

--- a/src/main/java/cloud/dnation/jenkins/plugins/hetzner/HetznerCloud.java
+++ b/src/main/java/cloud/dnation/jenkins/plugins/hetzner/HetznerCloud.java
@@ -209,6 +209,15 @@ public class HetznerCloud extends AbstractCloudImpl {
 
         @Restricted(NoExternalUse.class)
         @RequirePOST
+        public FormValidation doCheckCloudName(@QueryParameter String name) {
+            if (Helper.isValidLabelValue(name)) {
+                return FormValidation.ok();
+            }
+            return FormValidation.error("Cloud name is not a valid label value: %s", name);
+        }
+
+        @Restricted(NoExternalUse.class)
+        @RequirePOST
         public ListBoxModel doFillCredentialsIdItems(@AncestorInPath Item owner) {
             final StandardListBoxModel result = new StandardListBoxModel();
             if (owner == null) {

--- a/src/main/resources/cloud/dnation/jenkins/plugins/hetzner/HetznerCloud/config.jelly
+++ b/src/main/resources/cloud/dnation/jenkins/plugins/hetzner/HetznerCloud/config.jelly
@@ -16,7 +16,7 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:c="/lib/credentials" xmlns:st="jelly:stapler">
     <f:entry title="${%Name}" field="name">
-        <f:textbox default="hetzner"/>
+        <f:textbox default="hetzner" checkUrl="'${rootURL}/descriptorByName/cloud.dnation.jenkins.plugins.hetzner.HetznerCloud/checkCloudName?name='+escape(this.value)" />
     </f:entry>
     <f:entry field="instanceCapStr" title="${%Instance Cap}">
         <f:textbox default="10"/>

--- a/src/main/resources/cloud/dnation/jenkins/plugins/hetzner/HetznerCloud/help-name.html
+++ b/src/main/resources/cloud/dnation/jenkins/plugins/hetzner/HetznerCloud/help-name.html
@@ -14,5 +14,9 @@
  limitations under the License.
 -->
 <div>
-    Provide a name for this Hetzner Cloud
+    Provide a name for this Hetzner Cloud.
+    Must be a valid <a href="https://docs.hetzner.cloud/#labels">label value</a>.
+    <p>
+    <i>Valid label values must be a string of 63 characters or less and must be empty or begin and end with an alphanumeric character ([a-z0-9A-Z]) with dashes (-), underscores (_), dots (.), and alphanumerics between.</i>
+    </p>
 </div>

--- a/src/test/java/cloud/dnation/jenkins/plugins/hetzner/HelperTest.java
+++ b/src/test/java/cloud/dnation/jenkins/plugins/hetzner/HelperTest.java
@@ -65,4 +65,13 @@ public class HelperTest {
         assertFalse(Helper.isPossiblyLong("0"));
         assertFalse(Helper.isPossiblyLong("not-a-number"));
     }
+
+    @Test
+    public void testIsValidLabelValue() {
+        assertFalse(Helper.isValidLabelValue(""));
+        assertFalse(Helper.isValidLabelValue(null));
+        assertTrue(Helper.isValidLabelValue("cloud-01"));
+        assertTrue(Helper.isValidLabelValue("cloud_01"));
+        assertFalse(Helper.isValidLabelValue("cloud 01"));
+    }
 }


### PR DESCRIPTION
Currently there is no validation for cloud name,
but its value is being used in label expression while talking to Hetzner cloud API.

Add validation to config page and enhance documentation, so it's clear what is expected there.

Fixes: #75
