### PR TITLE
Add IllegalStateException catch to OrphanedNodesCleaner and BeforeHoursWrapsPolicy

### DIFF
--- a/src/main/java/cloud/dnation/jenkins/plugins/hetzner/OrphanedNodesCleaner.java
+++ b/src/main/java/cloud/dnation/jenkins/plugins/hetzner/OrphanedNodesCleaner.java
@@ -45,7 +45,11 @@ public class OrphanedNodesCleaner extends PeriodicWork {
 
     @Override
     protected void doRun() {
-        doCleanup();
+        try {
+            doCleanup();
+        } catch (IllegalStateException e) {
+            log.error("Error while cleaning up orphaned nodes", e);
+        }
     }
 
     static void doCleanup() {

--- a/src/main/java/cloud/dnation/jenkins/plugins/hetzner/shutdown/BeforeHourWrapsPolicy.java
+++ b/src/main/java/cloud/dnation/jenkins/plugins/hetzner/shutdown/BeforeHourWrapsPolicy.java
@@ -64,7 +64,7 @@ public class BeforeHourWrapsPolicy extends AbstractShutdownPolicy {
                     log.info("Disconnecting {}", c.getName());
                     try {
                         agent.terminate();
-                    } catch (InterruptedException | IOException e) {
+                    } catch (InterruptedException | IOException | IllegalStateException e) {
                         log.warn("Failed to terminate {}", c.getName(), e);
                     }
                 }


### PR DESCRIPTION
Seems to fix #89.

### Testing done

Ran this custom patch of the plugin for the last weeks, and node cleanup functions correctly with the BeforeHorusWrapPolicy now instead of crashing.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
