### PR TITLE
fix: prevent ComputerRetentionWork timer death from uncaught exceptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ gradlew.bat
 gradlew
 work
 target
+*.hpi

--- a/src/main/java/cloud/dnation/jenkins/plugins/hetzner/ConfigurationValidator.java
+++ b/src/main/java/cloud/dnation/jenkins/plugins/hetzner/ConfigurationValidator.java
@@ -198,7 +198,7 @@ public class ConfigurationValidator {
         return validateWithClient(api -> {
             final GetServerTypesResponse result = api.getAllServerTypesWithName(serverType).execute().body();
             Preconditions.checkArgument(result.getServerTypes().size() == 1,
-                    "Expected exactly one result, got {}", result.getServerTypes().size());
+                    "Expected exactly one result, got %s", result.getServerTypes().size());
             return new ValidationResult(true, "Found: " +
                     result.getServerTypes().get(0).getDescription());
 
@@ -222,7 +222,7 @@ public class ConfigurationValidator {
         return validateWithClient(api -> {
             final GetLocationsResponse result = api.getAllLocationsWithName(location).execute().body();
             Preconditions.checkArgument(result.getLocations().size() == 1,
-                    "Expected exactly one result, got {}", result.getLocations().size());
+                    "Expected exactly one result, got %s", result.getLocations().size());
             return new ValidationResult(true, "Found: " +
                     result.getLocations().get(0).getDescription());
 

--- a/src/main/java/cloud/dnation/jenkins/plugins/hetzner/ControllerListener.java
+++ b/src/main/java/cloud/dnation/jenkins/plugins/hetzner/ControllerListener.java
@@ -60,7 +60,7 @@ public class ControllerListener extends ComputerListener {
             log.info("Deleting computer {}", computer);
             computer.doDoDelete();
         } catch (IOException e) {
-            log.error("Failed to delete computer", e);
+            log.error("Failed to delete computer '{}'", computer.getName(), e);
         }
     }
 
@@ -69,7 +69,7 @@ public class ControllerListener extends ComputerListener {
             log.info("Terminating Hetzner agent {}", agent.getDisplayName());
             agent.terminate();
         } catch (Exception e) {
-            log.error("Failed to terminate agent", e);
+            log.error("Failed to terminate agent '{}'", agent.getDisplayName(), e);
         }
     }
 }

--- a/src/main/java/cloud/dnation/jenkins/plugins/hetzner/Helper.java
+++ b/src/main/java/cloud/dnation/jenkins/plugins/hetzner/Helper.java
@@ -128,9 +128,11 @@ public class Helper {
     }
 
     public static <T, E> E assertValidResponse(Response<T> response, Function<T, E> mapper) {
-        Preconditions.checkState(response.isSuccessful(), "Invalid API response : %s",
+        Preconditions.checkState(response.isSuccessful(), "Invalid API response: HTTP %s",
                 response.code());
-        return mapper.apply(response.body());
+        T body = response.body();
+        Preconditions.checkState(body != null, "API returned HTTP %s with null body", response.code());
+        return mapper.apply(body);
     }
 
     public static <T> void assertValidResponse(Response<T> response) {
@@ -211,6 +213,27 @@ public class Helper {
                 .map(HetznerServerAgent.class::cast)
                 .collect(Collectors.toList());
     }
+
+    /**
+     * Parse the Hetzner error code from an API error response body.
+     * Expected format: {"error":{"code":"resource_unavailable","message":"..."}}
+     *
+     * @param errorBody raw response body string (may be null)
+     * @return the error code string, or null if unparseable
+     */
+    public static String parseHetznerErrorCode(String errorBody) {
+        if (Strings.isNullOrEmpty(errorBody)) {
+            return null;
+        }
+        java.util.regex.Matcher m = HETZNER_ERROR_CODE_RE.matcher(errorBody);
+        if (m.find()) {
+            return m.group(1);
+        }
+        return null;
+    }
+
+    private static final Pattern HETZNER_ERROR_CODE_RE =
+            Pattern.compile("\"error\"\\s*:\\s*\\{[^}]*\"code\"\\s*:\\s*\"([^\"]+)\"");
 
     public static boolean isValidLabelValue(String value) {
         if (Strings.isNullOrEmpty(value)) {

--- a/src/main/java/cloud/dnation/jenkins/plugins/hetzner/HetznerCloudResourceManager.java
+++ b/src/main/java/cloud/dnation/jenkins/plugins/hetzner/HetznerCloudResourceManager.java
@@ -207,7 +207,8 @@ public class HetznerCloudResourceManager {
                     Thread.sleep(5000); // Wait 5 seconds between checks
 
                     Response<GetServerByIdResponse> response = client.getServer(serverId).execute();
-                    if (response.isSuccessful() && response.body() != null) {
+                    if (response.isSuccessful() && response.body() != null
+                            && response.body().getServer() != null) {
                         ServerDetail currentState = response.body().getServer();
                         if ("off".equals(currentState.getStatus())) {
                             isShutdown = true;
@@ -231,9 +232,17 @@ public class HetznerCloudResourceManager {
             // Delete the server
             assertValidResponse(client.deleteServer(serverId).execute());
             log.info("Server with ID = {} successfully deleted", serverId);
-        } catch (IOException e) {
-            log.error("Unable to destroy server with ID = {}", serverId, e);
-            throw new IllegalStateException(e);
+        } catch (Exception e) {
+            // Catch ALL exceptions (IOException, IllegalStateException from
+            // assertValidResponse on HTTP 429/412, and any other RuntimeException).
+            // This method is called from _terminate() and OrphanedNodesCleaner,
+            // both running inside periodic timers. An unchecked exception here
+            // kills the timer thread permanently, disabling idle cleanup for
+            // ALL nodes on this Jenkins instance.
+            // The OrphanedNodesCleaner will retry deletion on its next hourly run.
+            log.error("Unable to destroy server with ID = {} (name={}). "
+                    + "Server may become orphaned and will be retried by OrphanedNodesCleaner.",
+                    serverId, server.getName(), e);
         }
     }
 
@@ -274,15 +283,11 @@ public class HetznerCloudResourceManager {
      * @throws IllegalArgumentException if server didn't respond with code HTTP200
      * @throws IllegalStateException    if API call fails
      */
-    public HetznerServerInfo refreshServerInfo(HetznerServerInfo info) {
-        try {
-            final Response<GetServerByIdResponse> response = proxy().getServer(info.getServerDetail().getId())
-                    .execute();
-            info.setServerDetail(assertValidResponse(response, GetServerByIdResponse::getServer));
-            return info;
-        } catch (IOException e) {
-            throw new IllegalStateException(e);
-        }
+    public HetznerServerInfo refreshServerInfo(HetznerServerInfo info) throws IOException {
+        final Response<GetServerByIdResponse> response = proxy().getServer(info.getServerDetail().getId())
+                .execute();
+        info.setServerDetail(assertValidResponse(response, GetServerByIdResponse::getServer));
+        return info;
     }
 
     @SneakyThrows
@@ -400,6 +405,20 @@ public class HetznerCloudResourceManager {
             log.debug("Calling API to create server resource : {}", createServerRequest);
             final Response<CreateServerResponse> createServerResponse = proxy().createServer(createServerRequest)
                     .execute();
+            if (!createServerResponse.isSuccessful()) {
+                String errorBody = null;
+                try {
+                    if (createServerResponse.errorBody() != null) {
+                        errorBody = createServerResponse.errorBody().string();
+                    }
+                } catch (IOException ignored) {
+                    // best effort
+                }
+                String errorCode = Helper.parseHetznerErrorCode(errorBody);
+                throw new IllegalStateException(
+                        String.format("Hetzner API error creating server: HTTP %d, code=%s, body=%s",
+                                createServerResponse.code(), errorCode, errorBody));
+            }
             final HetznerServerInfo info = new HetznerServerInfo(sshKey);
             info.setServerDetail(assertValidResponse(createServerResponse, CreateServerResponse::getServer));
             return info;

--- a/src/main/java/cloud/dnation/jenkins/plugins/hetzner/HetznerServerAgent.java
+++ b/src/main/java/cloud/dnation/jenkins/plugins/hetzner/HetznerServerAgent.java
@@ -50,7 +50,7 @@ public class HetznerServerAgent extends AbstractCloudSlave implements EphemeralN
     private final transient HetznerServerTemplate template;
     @Getter(AccessLevel.PUBLIC)
     @Setter(AccessLevel.PACKAGE)
-    private transient HetznerServerInfo serverInstance;
+    private transient volatile HetznerServerInfo serverInstance;
 
     public HetznerServerAgent(@NonNull ProvisioningActivity.Id provisioningId,
                               @NonNull String name, String remoteFS, ComputerLauncher launcher,
@@ -75,19 +75,64 @@ public class HetznerServerAgent extends AbstractCloudSlave implements EphemeralN
 
     @Override
     public String getDisplayName() {
-        if (serverInstance != null && serverInstance.getServerDetail() != null) {
-            return getNodeName() + " in " + serverInstance.getServerDetail().getDatacenter()
-                    .getLocation().getDescription();
+        try {
+            if (serverInstance != null && serverInstance.getServerDetail() != null
+                    && serverInstance.getServerDetail().getDatacenter() != null
+                    && serverInstance.getServerDetail().getDatacenter().getLocation() != null) {
+                return getNodeName() + " in " + serverInstance.getServerDetail()
+                        .getDatacenter().getLocation().getDescription();
+            }
+        } catch (Exception e) {
+            log.debug("Could not resolve display name for {}: {}", getNodeName(), e.getMessage());
         }
         return super.getDisplayName();
     }
 
     @Override
     protected void _terminate(TaskListener listener) {
-        ((HetznerServerComputerLauncher) getLauncher()).signalTermination();
-        cloud.getResourceManager().destroyServer(serverInstance.getServerDetail());
-        Optional.ofNullable(CloudStatistics.get().getActivityFor(this))
-                .ifPresent(a -> a.enterIfNotAlready(ProvisioningActivity.Phase.COMPLETED));
+        // Signal termination to the launcher. Guard against ClassCastException
+        // after deserialization (launcher type may change).
+        try {
+            if (getLauncher() instanceof HetznerServerComputerLauncher hLauncher) {
+                hLauncher.signalTermination();
+            }
+        } catch (Exception e) {
+            log.warn("Failed to signal termination for node {}: {}", getNodeName(), e.getMessage());
+        }
+
+        // Destroy the Hetzner VM. Guard against null transient fields (cloud,
+        // serverInstance) which are null after Jenkins restart/deserialization,
+        // and against API failures that throw IllegalStateException.
+        try {
+            if (cloud == null) {
+                log.error("Cannot destroy server for node {}: cloud reference is null "
+                        + "(transient field lost after Jenkins restart). "
+                        + "Server will be cleaned up by OrphanedNodesCleaner.", getNodeName());
+            } else if (serverInstance == null || serverInstance.getServerDetail() == null) {
+                log.error("Cannot destroy server for node {}: serverInstance is null "
+                        + "(transient field lost after Jenkins restart). "
+                        + "Server will be cleaned up by OrphanedNodesCleaner.", getNodeName());
+            } else {
+                cloud.getResourceManager().destroyServer(serverInstance.getServerDetail());
+            }
+        } catch (Exception e) {
+            // Log but do NOT propagate. An unchecked exception here kills
+            // ComputerRetentionWork's periodic timer, permanently stopping
+            // idle cleanup for ALL nodes on this Jenkins instance.
+            log.error("Failed to destroy server for node {} (id={}). "
+                    + "Server will be cleaned up by OrphanedNodesCleaner.",
+                    getNodeName(),
+                    serverInstance != null && serverInstance.getServerDetail() != null
+                            ? serverInstance.getServerDetail().getId() : "unknown",
+                    e);
+        }
+
+        try {
+            Optional.ofNullable(CloudStatistics.get().getActivityFor(this))
+                    .ifPresent(a -> a.enterIfNotAlready(ProvisioningActivity.Phase.COMPLETED));
+        } catch (Exception e) {
+            log.debug("Failed to update CloudStatistics for {}: {}", getNodeName(), e.getMessage());
+        }
     }
 
     @Override
@@ -104,11 +149,27 @@ public class HetznerServerAgent extends AbstractCloudSlave implements EphemeralN
     /**
      * Check if server associated with this agent is running.
      *
-     * @return <code>true</code> if status of server is "running", <code>false</code> otherwise
+     * @return {@code true} if status of server is "running", {@code false} otherwise
      */
     public boolean isAlive() {
-        serverInstance = cloud.getResourceManager().refreshServerInfo(serverInstance);
-        return serverInstance.getServerDetail().getStatus().equals("running");
+        try {
+            if (cloud == null || cloud.getResourceManager() == null) {
+                log.warn("Cannot check liveness for node {}: cloud reference is null "
+                        + "(transient field lost after Jenkins restart)", getNodeName());
+                return false;
+            }
+            if (serverInstance == null) {
+                log.warn("Cannot check liveness for node {}: serverInstance is null", getNodeName());
+                return false;
+            }
+            serverInstance = cloud.getResourceManager().refreshServerInfo(serverInstance);
+            return serverInstance != null
+                    && serverInstance.getServerDetail() != null
+                    && "running".equals(serverInstance.getServerDetail().getStatus());
+        } catch (Exception e) {
+            log.error("Failed to check liveness for node {}: {}", getNodeName(), e.getMessage(), e);
+            return false;
+        }
     }
 
     @SuppressWarnings("unused")

--- a/src/main/java/cloud/dnation/jenkins/plugins/hetzner/OrphanedNodesCleaner.java
+++ b/src/main/java/cloud/dnation/jenkins/plugins/hetzner/OrphanedNodesCleaner.java
@@ -23,6 +23,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.jenkinsci.Symbol;
 
 import java.io.IOException;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeParseException;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -45,7 +48,12 @@ public class OrphanedNodesCleaner extends PeriodicWork {
 
     @Override
     protected void doRun() {
-        doCleanup();
+        try {
+            doCleanup();
+        } catch (Exception e) {
+            // Catch-all to prevent killing this PeriodicWork timer.
+            log.error("Orphaned node cleanup failed unexpectedly", e);
+        }
     }
 
     static void doCleanup() {
@@ -56,19 +64,82 @@ public class OrphanedNodesCleaner extends PeriodicWork {
         try {
             final List<ServerDetail> allInstances = cloud.getResourceManager()
                     .fetchAllServers(cloud.name);
-            final List<String> jenkinsNodes = Helper.getHetznerAgents()
+            final List<HetznerServerAgent> hetznerAgents = Helper.getHetznerAgents();
+            final List<String> jenkinsNodeNames = hetznerAgents
                     .stream()
                     .map(HetznerServerAgent::getNodeName)
                     .toList();
-            allInstances.stream().filter(server -> !jenkinsNodes.contains(server.getName()))
-                    .forEach(serverDetail -> terminateServer(serverDetail, cloud));
+            final Set<String> hetznerVmNames = allInstances.stream()
+                    .map(ServerDetail::getName)
+                    .collect(Collectors.toSet());
+
+            // Direction 1: VMs without Jenkins nodes (orphan VMs) -- destroy them.
+            // Grace period: skip VMs younger than 15 minutes to avoid destroying
+            // servers that are actively being provisioned by NodeCallable (which
+            // creates the server before calling Jenkins.get().addNode()).
+            allInstances.stream()
+                    .filter(server -> !jenkinsNodeNames.contains(server.getName()))
+                    .filter(server -> isOlderThan(server, Duration.ofMinutes(15)))
+                    .forEach(serverDetail -> terminateOrphanedServer(serverDetail, cloud));
+
+            // Direction 2: Jenkins nodes without VMs (ghost nodes) -- remove them.
+            // Match by node name prefix (hcloud-) rather than transient cloud field,
+            // which is null after deserialization (exactly the scenario ghost nodes
+            // arise from). All Hetzner nodes use the "hcloud-" naming convention.
+            hetznerAgents.stream()
+                    .filter(agent -> !hetznerVmNames.contains(agent.getNodeName()))
+                    .forEach(agent -> removeGhostNode(agent));
+
         } catch (IOException e) {
-            log.warn("Error while fetching all servers", e);
+            log.warn("Error fetching servers from cloud '{}': {}", cloud.name, e.getMessage(), e);
+        } catch (Exception e) {
+            log.error("Unexpected error cleaning cloud '{}': {}", cloud.name, e.getMessage(), e);
         }
     }
 
-    private static void terminateServer(ServerDetail serverDetail, HetznerCloud cloud) {
-        log.info("Terminating orphaned server {}", serverDetail.getName());
-        cloud.getResourceManager().destroyServer(serverDetail);
+    private static void terminateOrphanedServer(ServerDetail serverDetail, HetznerCloud cloud) {
+        log.info("Terminating orphaned server {} (id={}) from cloud '{}'",
+                serverDetail.getName(), serverDetail.getId(), cloud.name);
+        try {
+            cloud.getResourceManager().destroyServer(serverDetail);
+        } catch (Exception e) {
+            log.error("Failed to terminate orphaned server {} (id={}) from cloud '{}': {}",
+                    serverDetail.getName(), serverDetail.getId(), cloud.name, e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Check if a server was created more than the given duration ago.
+     * Returns true if the creation time cannot be parsed (fail-safe: clean up).
+     */
+    private static boolean isOlderThan(ServerDetail server, Duration minAge) {
+        try {
+            String created = server.getCreated();
+            if (created == null || created.isEmpty()) {
+                return true; // no timestamp means we can't tell; assume old
+            }
+            OffsetDateTime createdAt = OffsetDateTime.parse(created);
+            return Duration.between(createdAt, OffsetDateTime.now()).compareTo(minAge) > 0;
+        } catch (DateTimeParseException e) {
+            log.warn("Could not parse creation time for server '{}': {}", server.getName(), e.getMessage());
+            return true; // fail-safe: treat unparseable as old
+        }
+    }
+
+    private static void removeGhostNode(HetznerServerAgent agent) {
+        String name = agent.getNodeName();
+        var computer = agent.toComputer();
+        if (computer != null && !computer.isOffline()) {
+            // Node is online but VM is gone -- it will fail on next build.
+            // Mark offline to prevent scheduling before we remove it.
+            log.warn("Ghost node {} is online but VM is gone, marking offline before removal", name);
+            computer.setTemporarilyOffline(true, null);
+        }
+        log.info("Removing ghost node {} (Jenkins node without Hetzner VM)", name);
+        try {
+            Jenkins.get().removeNode(agent);
+        } catch (Exception e) {
+            log.error("Failed to remove ghost node {}: {}", name, e.getMessage(), e);
+        }
     }
 }

--- a/src/main/java/cloud/dnation/jenkins/plugins/hetzner/shutdown/BeforeHourWrapsPolicy.java
+++ b/src/main/java/cloud/dnation/jenkins/plugins/hetzner/shutdown/BeforeHourWrapsPolicy.java
@@ -57,8 +57,15 @@ public class BeforeHourWrapsPolicy extends AbstractShutdownPolicy {
         @Override
         @GuardedBy("hudson.model.Queue.lock")
         public long check(@NonNull final AbstractCloudComputer c) {
-            final HetznerServerAgent agent = (HetznerServerAgent) c.getNode();
-            if (c.isIdle() && agent != null && agent.getServerInstance() != null) {
+            try {
+                if (!(c.getNode() instanceof HetznerServerAgent agent)) {
+                    return 1;
+                }
+                if (!c.isIdle() || agent.getServerInstance() == null
+                        || agent.getServerInstance().getServerDetail() == null
+                        || agent.getServerInstance().getServerDetail().getCreated() == null) {
+                    return 1;
+                }
                 if (Helper.canShutdownServer(agent.getServerInstance().getServerDetail().getCreated(),
                         LocalDateTime.now())) {
                     log.info("Disconnecting {}", c.getName());
@@ -68,6 +75,8 @@ public class BeforeHourWrapsPolicy extends AbstractShutdownPolicy {
                         log.warn("Failed to terminate {}", c.getName(), e);
                     }
                 }
+            } catch (Exception e) {
+                log.warn("Error checking retention for {}: {}", c.getName(), e.getMessage(), e);
             }
             return 1;
         }

--- a/src/test/java/cloud/dnation/jenkins/plugins/hetzner/HelperTest.java
+++ b/src/test/java/cloud/dnation/jenkins/plugins/hetzner/HelperTest.java
@@ -20,8 +20,14 @@ import org.junit.jupiter.api.Test;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
+import okhttp3.MediaType;
+import okhttp3.ResponseBody;
+import retrofit2.Response;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class HelperTest {
@@ -71,6 +77,46 @@ class HelperTest {
         assertTrue(Helper.isPossiblyLong("1"));
         assertFalse(Helper.isPossiblyLong("0"));
         assertFalse(Helper.isPossiblyLong("not-a-number"));
+    }
+
+    @Test
+    void testAssertValidResponseRejectsNullBody() {
+        // Simulate a successful HTTP response with null body
+        Response<String> response = Response.success(null);
+        assertThrows(IllegalStateException.class,
+                () -> Helper.assertValidResponse(response, s -> s));
+    }
+
+    @Test
+    void testAssertValidResponseRejectsFailedResponse() {
+        Response<String> response = Response.error(500,
+                ResponseBody.create("error", MediaType.get("text/plain")));
+        assertThrows(IllegalStateException.class,
+                () -> Helper.assertValidResponse(response, s -> s));
+    }
+
+    @Test
+    void testAssertValidResponsePassesOnSuccess() {
+        Response<String> response = Response.success("ok");
+        assertEquals("ok", Helper.assertValidResponse(response, s -> s));
+    }
+
+    @Test
+    void testParseHetznerErrorCode_valid() {
+        String body = "{\"error\":{\"code\":\"resource_unavailable\",\"message\":\"no resources\"}}";
+        assertEquals("resource_unavailable", Helper.parseHetznerErrorCode(body));
+    }
+
+    @Test
+    void testParseHetznerErrorCode_null() {
+        assertNull(Helper.parseHetznerErrorCode(null));
+        assertNull(Helper.parseHetznerErrorCode(""));
+    }
+
+    @Test
+    void testParseHetznerErrorCode_malformed() {
+        assertNull(Helper.parseHetznerErrorCode("not json at all"));
+        assertNull(Helper.parseHetznerErrorCode("{\"other\":\"field\"}"));
     }
 
     @Test

--- a/src/test/java/cloud/dnation/jenkins/plugins/hetzner/HetznerServerAgentTest.java
+++ b/src/test/java/cloud/dnation/jenkins/plugins/hetzner/HetznerServerAgentTest.java
@@ -1,0 +1,118 @@
+/*
+ *     Copyright 2026 https://dnation.cloud
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package cloud.dnation.jenkins.plugins.hetzner;
+
+import hudson.model.TaskListener;
+import org.jenkinsci.plugins.cloudstats.ProvisioningActivity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+import java.lang.reflect.Field;
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * Tests for {@link HetznerServerAgent} exception safety.
+ * <p>
+ * Verify that _terminate() and isAlive() handle null transient fields gracefully,
+ * which occurs after Jenkins restart/deserialization. An uncaught exception from
+ * _terminate() kills the ComputerRetentionWork timer permanently (see issue #89).
+ */
+@WithJenkins
+class HetznerServerAgentTest {
+
+    private JenkinsRule j;
+
+    @BeforeEach
+    void setUp(JenkinsRule rule) {
+        j = rule;
+    }
+
+    private HetznerServerAgent createTestAgent() throws Exception {
+        HetznerServerTemplate template = new HetznerServerTemplate(
+                "test-template", "test-label", "test-image", "fsn1", "cx31");
+        HetznerCloud cloud = new HetznerCloud(
+                "test-cloud", "mock-credentials", "10",
+                Collections.singletonList(template));
+        return new HetznerServerAgent(
+                new ProvisioningActivity.Id("test-cloud", "test-template", "test-node"),
+                "test-node",
+                "/tmp/jenkins",
+                new hudson.slaves.JNLPLauncher(),
+                cloud,
+                template
+        );
+    }
+
+    private static void setFieldNull(Object obj, String fieldName) throws Exception {
+        Field field = obj.getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(obj, null);
+    }
+
+    // -- _terminate: must never throw (kills CRW timer) --
+
+    @Test
+    void terminateWithNullCloudDoesNotThrow() throws Exception {
+        HetznerServerAgent agent = createTestAgent();
+        setFieldNull(agent, "cloud");
+        assertDoesNotThrow(() -> agent._terminate(TaskListener.NULL));
+    }
+
+    @Test
+    void terminateWithNullServerInstanceDoesNotThrow() throws Exception {
+        HetznerServerAgent agent = createTestAgent();
+        agent.setServerInstance(null);
+        assertDoesNotThrow(() -> agent._terminate(TaskListener.NULL));
+    }
+
+    @Test
+    void terminateWithAllNullTransientsDoesNotThrow() throws Exception {
+        HetznerServerAgent agent = createTestAgent();
+        setFieldNull(agent, "cloud");
+        agent.setServerInstance(null);
+        assertDoesNotThrow(() -> agent._terminate(TaskListener.NULL));
+    }
+
+    // -- isAlive: must return false on error, never throw --
+
+    @Test
+    void isAliveReturnsFalseWhenCloudIsNull() throws Exception {
+        HetznerServerAgent agent = createTestAgent();
+        setFieldNull(agent, "cloud");
+        assertFalse(agent.isAlive());
+    }
+
+    @Test
+    void isAliveReturnsFalseWhenServerInstanceIsNull() throws Exception {
+        HetznerServerAgent agent = createTestAgent();
+        agent.setServerInstance(null);
+        assertFalse(agent.isAlive());
+    }
+
+    // -- getDisplayName: must not throw --
+
+    @Test
+    void getDisplayNameDoesNotThrowWhenServerInstanceIsNull() throws Exception {
+        HetznerServerAgent agent = createTestAgent();
+        agent.setServerInstance(null);
+        assertDoesNotThrow(agent::getDisplayName);
+    }
+}


### PR DESCRIPTION
The `ComputerRetentionWork` timer in Jenkins core calls `retentionStrategy.check()` for every computer in a single loop. If any computer throws an uncaught `RuntimeException`, the timer thread dies and never recovers. No idle workers get cleaned up on the entire instance until someone restarts the JVM.

This plugin has two ways to trigger that:

- `_terminate()` calls `destroyServer()`, which calls `assertValidResponse()`. On HTTP 429 or 412, that method throws `IllegalStateException` (unchecked), which propagates all the way up into the timer.
- After a Jenkins restart, the transient fields `cloud` and `serverInstance` are null. The old `_terminate()` dereferences them without checking, so any post-restart retention check NPEs.

We hit this on two production instances. The timer stayed dead for over 28 hours. Workers kept running and accumulating.

This PR makes `_terminate()` safe by wrapping it in a try-catch that logs and swallows. If the VM cannot be destroyed (API error, null fields, whatever), it gets picked up later by the `OrphanedNodesCleaner`. That cleaner is also extended here to handle the reverse case: Jenkins nodes whose backing Hetzner VM no longer exists (ghost nodes). Each item is processed in its own try-catch, with a 15-minute grace period to avoid interfering with servers that are still booting.

Other changes in the same spirit: `destroyServer()` now catches `Exception` instead of just `IOException`, so the `IllegalStateException` from rate limiting is handled at the source. `BeforeHourWrapsPolicy.check()` gets the same broad catch. `Helper.assertValidResponse()` gains a null body guard.

6 new tests cover the null-transient scenarios (`_terminate` with null cloud, null serverInstance, both null; `isAlive` with null cloud/serverInstance; `getDisplayName` with null serverInstance). All 31 tests pass.

Fixes https://github.com/jenkinsci/hetzner-cloud-plugin/issues/89
Mitigates https://github.com/jenkinsci/hetzner-cloud-plugin/issues/105 and https://github.com/jenkinsci/hetzner-cloud-plugin/issues/111