### PR TITLE
fix: scope ghost-node cleanup to owning cloud in multi-cloud setups

### DIFF
--- a/src/main/java/cloud/dnation/jenkins/plugins/hetzner/HetznerServerAgent.java
+++ b/src/main/java/cloud/dnation/jenkins/plugins/hetzner/HetznerServerAgent.java
@@ -41,8 +41,16 @@ import java.util.Optional;
 @Slf4j
 public class HetznerServerAgent extends AbstractCloudSlave implements EphemeralNode, TrackedItem {
     @Serial
-    private static final long serialVersionUID = 1;
+    private static final long serialVersionUID = 2;
     private final ProvisioningActivity.Id provisioningId;
+    /**
+     * Persistent cloud name for identifying which cloud owns this agent.
+     * Unlike the transient {@link #cloud} field, this survives Jenkins
+     * restart/deserialization and can be used by {@link OrphanedNodesCleaner}
+     * to scope ghost-node detection to the correct cloud.
+     */
+    @Getter
+    private final String cloudName;
     @Getter
     private final transient HetznerCloud cloud;
     @Getter
@@ -58,6 +66,7 @@ public class HetznerServerAgent extends AbstractCloudSlave implements EphemeralN
             throws IOException, Descriptor.FormException {
         super(name, remoteFS, launcher);
         this.cloud = Objects.requireNonNull(cloud);
+        this.cloudName = cloud.name;
         this.template = Objects.requireNonNull(template);
         this.provisioningId = Objects.requireNonNull(provisioningId);
         setLabelString(template.getLabelStr());

--- a/src/main/java/cloud/dnation/jenkins/plugins/hetzner/OrphanedNodesCleaner.java
+++ b/src/main/java/cloud/dnation/jenkins/plugins/hetzner/OrphanedNodesCleaner.java
@@ -83,10 +83,16 @@ public class OrphanedNodesCleaner extends PeriodicWork {
                     .forEach(serverDetail -> terminateOrphanedServer(serverDetail, cloud));
 
             // Direction 2: Jenkins nodes without VMs (ghost nodes) -- remove them.
-            // Match by node name prefix (hcloud-) rather than transient cloud field,
-            // which is null after deserialization (exactly the scenario ghost nodes
-            // arise from). All Hetzner nodes use the "hcloud-" naming convention.
+            // IMPORTANT: only consider agents that belong to THIS cloud.
+            // Helper.getHetznerAgents() returns agents from ALL Hetzner clouds,
+            // so without filtering, a cloud with 0 VMs would incorrectly remove
+            // every agent from every other cloud as a "ghost node".
+            //
+            // We use the persistent cloudName field (survives deserialization)
+            // to scope the check. Agents created before this field existed will
+            // have cloudName == null; we skip those to avoid false positives.
             hetznerAgents.stream()
+                    .filter(agent -> cloud.name.equals(agent.getCloudName()))
                     .filter(agent -> !hetznerVmNames.contains(agent.getNodeName()))
                     .forEach(agent -> removeGhostNode(agent));
 

--- a/src/test/java/cloud/dnation/jenkins/plugins/hetzner/HetznerServerAgentTest.java
+++ b/src/test/java/cloud/dnation/jenkins/plugins/hetzner/HetznerServerAgentTest.java
@@ -26,7 +26,9 @@ import java.lang.reflect.Field;
 import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * Tests for {@link HetznerServerAgent} exception safety.
@@ -114,5 +116,22 @@ class HetznerServerAgentTest {
         HetznerServerAgent agent = createTestAgent();
         agent.setServerInstance(null);
         assertDoesNotThrow(agent::getDisplayName);
+    }
+
+    // -- cloudName: persistent field for multi-cloud ghost node scoping --
+
+    @Test
+    void cloudNameIsSetFromCloudOnConstruction() throws Exception {
+        HetznerServerAgent agent = createTestAgent();
+        assertEquals("test-cloud", agent.getCloudName());
+    }
+
+    @Test
+    void cloudNameSurvivesWhenTransientCloudFieldIsNull() throws Exception {
+        HetznerServerAgent agent = createTestAgent();
+        setFieldNull(agent, "cloud");
+        assertNull(agent.getCloud());
+        assertEquals("test-cloud", agent.getCloudName(),
+                "cloudName must survive after transient cloud field is nulled (deserialization)");
     }
 }


### PR DESCRIPTION
## Summary

The ghost-node detection added in 796d19b (v106) has a critical bug in multi-cloud setups: `Helper.getHetznerAgents()` returns agents from **all** Hetzner clouds, but `fetchAllServers(cloud.name)` only returns VMs for **one** cloud. When any cloud has 0 running VMs, the cleaner treats every agent from every other cloud as a "ghost node" and removes them — killing active builds.

### Reproduction scenario

1. Configure 2+ `HetznerCloud` instances (e.g. `cloud-A` with running VMs, `cloud-B` with 0 VMs)
2. Wait for `OrphanedNodesCleaner` to run (hourly)
3. During `cloud-B`'s cleanup iteration:
   - `fetchAllServers("cloud-B")` → empty list
   - `getHetznerAgents()` → returns agents from **both** clouds
   - Every `cloud-A` agent is "not in the empty set" → **incorrectly removed as ghost node**
4. All active builds on `cloud-A` agents are aborted with `AgentOfflineException: Node is being removed`

This is especially destructive when one cloud cannot provision VMs at all (e.g. image/server-type mismatch), guaranteeing it always has 0 VMs and triggers mass-deletion every hour.

### Root cause

The `cloud` field on `HetznerServerAgent` is `transient` (null after deserialization), so the cleaner cannot determine which cloud owns which agent. The v106 code acknowledges this in comments but uses no alternative ownership check, effectively making ghost-node detection global instead of per-cloud.

### Fix

- Add a **persistent** `cloudName` field to `HetznerServerAgent` (non-transient, survives restart)
- Set it from `cloud.name` during construction
- Filter agents by `cloudName` in `OrphanedNodesCleaner.cleanCloud()` before ghost-node comparison
- Bump `serialVersionUID` to 2

Agents created before this fix will have `cloudName == null` and are safely skipped by the filter (`cloud.name.equals(null)` returns `false`), so there are no backward compatibility issues — they simply won't be candidates for ghost-node cleanup until they are reprovisioned.

### Tests

- `cloudNameIsSetFromCloudOnConstruction` — verifies the field is populated
- `cloudNameSurvivesWhenTransientCloudFieldIsNull` — simulates deserialization scenario

## Test plan

- [ ] Existing tests pass
- [ ] New tests pass
- [ ] Manual verification: configure 2+ HetznerCloud instances sharing the same API token, with one cloud unable to provision (e.g. wrong server type). Verify OrphanedNodesCleaner no longer removes agents from other clouds.